### PR TITLE
BugFix : mallangShopBeta_JSONException #98

### DIFF
--- a/mallangShopBeta/src/main/java/com/mallang/mallangshopbeta/naver/dto/ItemDto.java
+++ b/mallangShopBeta/src/main/java/com/mallang/mallangshopbeta/naver/dto/ItemDto.java
@@ -15,15 +15,15 @@ public class ItemDto {
 
     private String image;
 
-    private int lowPrice;
+    private int lprice;
 
     // 생성자
     @Builder
-    private ItemDto(String title, String link, String image, int lowPrice) {
+    private ItemDto(String title, String link, String image, int lprice) {
         this.title = title;
         this.link = link;
         this.image = image;
-        this.lowPrice = lowPrice;
+        this.lprice = lprice;
     }
 
     // 정적팩토리메서드
@@ -31,8 +31,8 @@ public class ItemDto {
         return ItemDto.builder()
                 .title(itemJson.getString("title"))
                 .link(itemJson.getString("link"))
-                .image(itemJson.getString(("image")))
-                .lowPrice(itemJson.getInt("lowPrice"))
+                .image(itemJson.getString("image"))
+                .lprice(itemJson.getInt("lprice"))
                 .build();
     }
 


### PR DESCRIPTION
```
org.json.JSONException: JSONObject["lowPrice"] not found.
JSONObject["lowPrice"] not found.] with root cause
```

## 📍 문제상황 및 원인
- `ItemDto`에 있는 `lowPrice` → `lowPrice`를 key로 값을 찾아오지 못하는 상태 🚨
- Json → Dto 변환과정에서 Null 값이 오면 안됨 ⭐️

### 💡 1차시도
- NaverAPI에서 받아오는 `lowPrice` 중, Null 값이 있음을 가정하고 정적팩토리메서드 `of`수정
``` java
public static ItemDto of(JSONObject itemJson) {
    return ItemDto.builder()
        .title(itemJson.getString("title"))
        .link(itemJson.getString("link"))
        .image(itemJson.getString("image"))
        .lowPrice(itemJson.optInt("lowPrice", 0))
        .build();
}
```
- ➡️ Postman 확인결과, 모든 `lowPrice`가 defalutValue인 0으로 반환됨
- ➡️ 잘못된 해결방법

## 📍 해결
- NaverAPI에서 최저가를 `lprice`로 넘겨주고 있었음
- 때문에, JSON에서 key를 못찾아 Null값 Exception Error가 발생한 것 🚨
``` java
ItemDto의 lowPrice → 모두 lprice로 리팩토링
```